### PR TITLE
Fixes/youtube als quelle entfernen

### DIFF
--- a/src/main/java/com/quartel/discordbot/modules/music/commands/PlayCommand.java
+++ b/src/main/java/com/quartel/discordbot/modules/music/commands/PlayCommand.java
@@ -101,10 +101,11 @@ public class PlayCommand {
         // Extrahiere den Song-Parameter aus dem Befehl
         String song = event.getOption("song").getAsString();
 
-        // Wenn es keine vollständige URL ist, behandle es als YouTube-Suche
+
+        // Prüfen, ob es eine URL ist, da direkte Suche nicht mehr unterstützt wird
         if (!isUrl(song)) {
-            song = "ytsearch:" + song;
-            LOGGER.debug("Suche nach: {}", song);
+            event.reply("❌ Bitte gib eine direkte URL ein. Die Suchfunktion wird momentan nicht unterstützt.").setEphemeral(true).queue();
+            return;
         }
 
         // Lade und spiele den Track

--- a/src/main/java/com/quartel/discordbot/modules/music/player/PlayerManager.java
+++ b/src/main/java/com/quartel/discordbot/modules/music/player/PlayerManager.java
@@ -5,6 +5,11 @@ import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
+import com.sedmelluq.discord.lavaplayer.source.bandcamp.BandcampAudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.source.http.HttpAudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
@@ -49,8 +54,22 @@ public class PlayerManager {
         this.audioPlayerManager = new DefaultAudioPlayerManager();
         this.scheduler = Executors.newScheduledThreadPool(1);
 
-        // Registriere alle Quellen, von denen Musik geladen werden kann
-        AudioSourceManagers.registerRemoteSources(audioPlayerManager);
+        // SoundCloud unterstützen
+        audioPlayerManager.registerSourceManager(SoundCloudAudioSourceManager.createDefault());
+
+        // Bandcamp unterstützen
+        audioPlayerManager.registerSourceManager(new BandcampAudioSourceManager());
+
+        // Twitch-Streams unterstützen
+        audioPlayerManager.registerSourceManager(new TwitchStreamAudioSourceManager());
+
+        // Vimeo unterstützen
+        audioPlayerManager.registerSourceManager(new VimeoAudioSourceManager());
+
+        // Allgemeine HTTP-Quellen unterstützen (für direktes Streamen von URLs)
+        audioPlayerManager.registerSourceManager(new HttpAudioSourceManager());
+
+        // Lokale Dateien unterstützen
         AudioSourceManagers.registerLocalSource(audioPlayerManager);
 
         // Starte einen Timer, der inaktive Verbindungen überprüft

--- a/src/main/java/com/quartel/discordbot/modules/music/util/MusicUtil.java
+++ b/src/main/java/com/quartel/discordbot/modules/music/util/MusicUtil.java
@@ -157,7 +157,7 @@ public class MusicUtil {
                 .addField("Lautstärke", musicManager.getVolume() + "%", true)
                 .addField("Fortschritt", progressBar.toString(), false)
                 .setColor(Color.GREEN)
-                .setThumbnail(getYouTubeThumbnail(info.uri))
+                .setThumbnail(getMusicThumbnail(info.uri))
                 .setFooter("Angefordert von " + guild.getSelfMember().getUser().getName(), guild.getSelfMember().getUser().getAvatarUrl())
                 .build();
     }
@@ -244,20 +244,15 @@ public class MusicUtil {
     }
 
     /**
-     * Holt die Thumbnail-URL für ein YouTube-Video.
+     * Holt die Thumbnail-URL für eine Musikquelle.
+     * Gibt standardmäßig ein generisches Musiksymbol zurück, da die direkte Thumbnail-Extraktion
+     * für bestimmte Quellen nicht mehr unterstützt wird.
      *
-     * @param videoUrl Die URL des YouTube-Videos
-     * @return Die URL des Thumbnails oder ein Standardbild
+     * @param sourceUrl Die URL der Musikquelle
+     * @return Die URL eines Standard-Musiksymbols
      */
-    private static String getYouTubeThumbnail(String videoUrl) {
-        if (videoUrl != null && videoUrl.contains("youtube.com/watch?v=")) {
-            String videoId = videoUrl.split("v=")[1];
-            if (videoId.contains("&")) {
-                videoId = videoId.split("&")[0];
-            }
-            return "https://img.youtube.com/vi/" + videoId + "/mqdefault.jpg";
-        }
-
-        return "https://i.imgur.com/HQoJfpG.png"; // Standard-Musiksymbol
+    private static String getMusicThumbnail(String sourceUrl) {
+        // Verwende immer das Standard-Musiksymbol
+        return "https://i.imgur.com/HQoJfpG.png";
     }
 }


### PR DESCRIPTION
## Beschreibung der Änderungen

### Was wurde geändert?
- [Youtube Thumbnail durch generisches Thumbnail für alle Quellen ersetzt](https://github.com/Quartel/discord-adelheit/commit/075140e23c5c13473e246a92a0034b4c39630b12)
- [Youtube Suche entfernt](https://github.com/Quartel/discord-adelheit/commit/28c80844c04808c456608acfc8b602cf77faf5fd)
- [Unterstütze Quelle einzeln registriert. Ohne Youtube.](https://github.com/Quartel/discord-adelheit/commit/d48e9a669e065960a3de74d728994775d130e297)

### Warum wurde es geändert?
- Youtube funktioniert aktuell nicht.

### Art der Änderung
- [ ] Neue Funktion (non-breaking change)
- [ ] Bugfix (non-breaking change)
- [ ] Breaking Change
- [ ] Dokumentationsupdate

### Zusätzliche Hinweise
- 

### Checkliste
- [X] Ich habe meine Änderungen getestet
- [ ] Ich habe Dokumentation aktualisiert
- [ ] Mein Code folgt dem Projektstil
- [ ] Ich habe entsprechende Tests hinzugefügt